### PR TITLE
Implement MealModel with CRUD operations and PrismaClient singleton

### DIFF
--- a/src/models/__test__/meal-model.test.ts
+++ b/src/models/__test__/meal-model.test.ts
@@ -1,0 +1,128 @@
+import type { Meal } from '@prisma/client';
+
+import type { CreateMealData } from '../meal-model';
+
+import { NotFound } from '../../errors/not-found-error';
+import { prismaMock } from '../../test/setup';
+import { MealModel } from '../meal-model';
+
+describe('meal-model', () => {
+  // Test data
+  const mockMeal: Meal = {
+    id: '123e4567-e89b-12d3-a456-426614174001',
+    name: 'Chicken Salad',
+    calories: 350,
+    carbs: 20,
+    protein: 30,
+    fat: 15,
+    createdAt: new Date(),
+    planId: 'plan123',
+  };
+
+  const mockCreateMealData: CreateMealData = {
+    name: 'Chicken Salad',
+    calories: 350,
+    carbs: 20,
+    protein: 30,
+    fat: 15,
+    planId: 'plan123',
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('create', () => {
+    it('should create a new meal successfully', async () => {
+      // Arrange
+      prismaMock.meal.create.mockResolvedValue(mockMeal);
+
+      // Act
+      const result = await MealModel.create(mockCreateMealData);
+
+      // Assert
+      expect(prismaMock.meal.create).toHaveBeenCalledWith({
+        data: mockCreateMealData,
+      });
+      expect(result).toEqual(mockMeal);
+    });
+  });
+
+  describe('findById', () => {
+    it('should return a meal when found by id', async () => {
+      // Arrange
+      prismaMock.meal.findUnique.mockResolvedValue(mockMeal);
+
+      // Act
+      const result = await MealModel.findById(mockMeal.id);
+
+      // Assert
+      expect(prismaMock.meal.findUnique).toHaveBeenCalledWith({
+        where: { id: mockMeal.id },
+      });
+      expect(result).toEqual(mockMeal);
+    });
+
+    it('should throw NotFound if meal does not exist', async () => {
+      // Arrange
+      prismaMock.meal.findUnique.mockResolvedValue(null);
+
+      // Act & Assert
+      await expect(MealModel.findById('nonexistent-id')).rejects.toThrow(NotFound);
+      await expect(MealModel.findById('nonexistent-id')).rejects.toThrow('Meal not found');
+    });
+  });
+
+  describe('updateById', () => {
+    it('should update a meal successfully', async () => {
+      // Arrange
+      const updatedMeal = { ...mockMeal, name: 'Updated Meal' };
+      prismaMock.meal.update.mockResolvedValue(updatedMeal);
+
+      // Act
+      const result = await MealModel.updateById(mockMeal.id, { name: 'Updated Meal' });
+
+      // Assert
+      expect(prismaMock.meal.update).toHaveBeenCalledWith({
+        where: { id: mockMeal.id },
+        data: { name: 'Updated Meal' },
+      });
+      expect(result).toEqual(updatedMeal);
+    });
+
+    it('should throw NotFound if meal does not exist', async () => {
+      // Arrange
+      const prismaError = new Error('Record not found');
+      Object.defineProperty(prismaError, 'code', { value: 'P2025' });
+      prismaMock.meal.update.mockRejectedValue(prismaError);
+
+      // Act & Assert
+      await expect(MealModel.updateById('nonexistent-id', { name: 'Updated Meal' })).rejects.toThrow(NotFound);
+    });
+  });
+
+  describe('deleteById', () => {
+    it('should delete a meal successfully', async () => {
+      // Arrange
+      prismaMock.meal.delete.mockResolvedValue(mockMeal);
+
+      // Act
+      await MealModel.deleteById(mockMeal.id);
+
+      // Assert
+      expect(prismaMock.meal.delete).toHaveBeenCalledWith({
+        where: { id: mockMeal.id },
+      });
+    });
+
+    it('should throw NotFound if meal does not exist', async () => {
+      // Arrange
+      const prismaError = new Error('Record not found');
+      Object.defineProperty(prismaError, 'code', { value: 'P2025' });
+      prismaMock.meal.delete.mockRejectedValue(prismaError);
+
+      // Act & Assert
+      await expect(MealModel.deleteById('nonexistent-id')).rejects.toThrow(NotFound);
+    });
+  });
+});

--- a/src/models/meal-model.ts
+++ b/src/models/meal-model.ts
@@ -1,0 +1,94 @@
+import type { Meal } from '@prisma/client';
+
+import { NotFound } from '../errors/not-found-error';
+import { prisma } from './prisma-client/prima-client';
+
+export type CreateMealData = Omit<Meal, 'id' | 'createdAt' | 'planId'> & {
+  planId: string;
+};
+
+export type UpdateMealData = Partial<Omit<Meal, 'id' | 'createdAt' | 'planId'>>;
+
+export class MealModel {
+  /**
+   * Create a new meal
+   * @param mealData - Meal data to create
+   * @returns Newly created meal
+   */
+  static async create(mealData: CreateMealData): Promise<Meal> {
+    try {
+      return await prisma.meal.create({
+        data: mealData,
+      });
+    }
+    catch (error) {
+      MealModel.handlePrismaError(error);
+      throw error;
+    }
+  }
+
+  /**
+   * Find meal by ID
+   * @param id - Meal ID to find
+   * @returns Meal if found
+   * @throws NotFound if meal doesn't exist
+   */
+  static async findById(id: string): Promise<Meal> {
+    const meal = await prisma.meal.findUnique({ where: { id } });
+
+    if (!meal) {
+      throw new NotFound('Meal not found');
+    }
+
+    return meal;
+  }
+
+  /**
+   * Update meal by ID
+   * @param id - Meal ID to update
+   * @param mealData - Meal data to update
+   * @returns Updated meal
+   * @throws NotFound if meal doesn't exist
+   */
+
+  static async updateById(id: string, mealData: UpdateMealData): Promise<Meal> {
+    try {
+      return await prisma.meal.update({
+        where: { id },
+        data: mealData,
+      });
+    }
+    catch (error: any) {
+      MealModel.handlePrismaError(error);
+      throw error; // Re-throw unexpected errors
+    }
+  }
+
+  /**
+   * Delete meal by ID
+   * @param id - Meal ID to delete
+   * @throws NotFound if meal doesn't exist
+   */
+
+  static async deleteById(id: string): Promise<void> {
+    try {
+      await prisma.meal.delete({ where: { id } });
+    }
+    catch (error: any) {
+      MealModel.handlePrismaError(error);
+      throw error; // Re-throw unexpected errors
+    }
+  }
+
+  /**
+   * handle Prisma errors
+   * @param error - Prisma error to handle
+   * @throws NotFound if meal doesn't exist
+   * @throws void for unhandled errors
+   */
+  private static handlePrismaError(error: any): never | void {
+    if (error.code === 'P2025') {
+      throw new NotFound('Meal not found');
+    }
+  }
+}

--- a/src/models/prisma-client/prima-client.ts
+++ b/src/models/prisma-client/prima-client.ts
@@ -1,0 +1,17 @@
+import { PrismaClient } from '@prisma/client';
+
+class PrismaClientSingleton {
+  private static instance: PrismaClient;
+
+  public static getInstance(): PrismaClient {
+    if (!PrismaClientSingleton.instance) {
+      PrismaClientSingleton.instance = new PrismaClient();
+    }
+    return PrismaClientSingleton.instance;
+  }
+}
+
+// Use the singleton
+const prisma = PrismaClientSingleton.getInstance();
+
+export { prisma };

--- a/src/models/user-model.ts
+++ b/src/models/user-model.ts
@@ -1,25 +1,9 @@
 import type { User } from '@prisma/client';
 
-import { PrismaClient } from '@prisma/client';
-
 import { BadRequestError } from '../errors/bad-request-error';
 import { NotFound } from '../errors/not-found-error';
 import { Password } from '../utils/password';
-
-// Singleton pattern for Prisma client
-class PrismaClientSingleton {
-  private static instance: PrismaClient;
-
-  public static getInstance(): PrismaClient {
-    if (!PrismaClientSingleton.instance) {
-      PrismaClientSingleton.instance = new PrismaClient();
-    }
-    return PrismaClientSingleton.instance;
-  }
-}
-
-// Use the singleton
-const prisma = PrismaClientSingleton.getInstance();
+import { prisma } from './prisma-client/prima-client';
 
 // Interfaces for better type safety and reusability
 export type CreateUserData = {


### PR DESCRIPTION
Introduce a singleton implementation for PrismaClient to manage database access. Implement MealModel with CRUD operations for meal management and add unit tests for its methods. Refactor the user model to utilize the shared PrismaClient instance.